### PR TITLE
FIX: Fix broken pydantic dependency in delete_subscription

### DIFF
--- a/src/subscription_delete/requirements.txt
+++ b/src/subscription_delete/requirements.txt
@@ -1,2 +1,3 @@
 aws_lambda_powertools==2.9.1
 fhir.resources==6.5.0
+pydantic==1.10.5

--- a/src/subscription_delete/subscription_delete/app.py
+++ b/src/subscription_delete/subscription_delete/app.py
@@ -7,7 +7,6 @@ from subscription_delete.utils import operation_outcome_lambda_response_factory
 
 _LOGGER = Logger()
 
-
 @_LOGGER.inject_lambda_context(log_event=False)
 def lambda_handler(event: dict, context: LambdaContext):
     try:
@@ -17,14 +16,14 @@ def lambda_handler(event: dict, context: LambdaContext):
             status_code=500,
             severity="error",
             code="exception",
-            diagnostics="Provided subscription id is not a valid UUID",
+            diagnostics="Provided subscription ID is not a valid UUID",
         )
     except KeyError:
         return operation_outcome_lambda_response_factory(
             status_code=500,
             severity="error",
             code="exception",
-            diagnostics="Missing subscription id in path parameters",
+            diagnostics="Missing subscription ID in path parameters",
         )
 
     return {"statusCode": 200}


### PR DESCRIPTION
Recent pydantic changes are meaning it fails to import in Python 3.9 - this is not happening in `create_subscription` because the version is fixed and apparently it is not fixed to a version upstream in `fhir_resources`.

This has been tested and fixes the issue